### PR TITLE
Add method to decode UCS-2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ucs2"
-version = "0.2.0"
-authors = ["Gabriel Majeri <gabriel.majeri6@gmail.com>", "Fredrik Aleksander"]
+version = "0.3.0"
+authors = ["Gabriel Majeri <gabriel.majeri6@gmail.com>", "Fredrik Aleksander", "Isaac Woods"]
 description = "UCS-2 decoding and encoding functions"
 repository = "https://github.com/GabrielMajeri/ucs2-rs"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 keywords = ["ucs2", "no-std", "encoding"]
 categories = ["encoding", "no-std"]
 license = "MPL-2.0"
+edition = "2018"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "https://github.com/GabrielMajeri/ucs2-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["encoding", "no-std"]
 license = "MPL-2.0"
 edition = "2018"
 
+[dependencies]
+bit_field = "0.10"
+
 [badges]
 is-it-maintained-issue-resolution = { repository = "https://github.com/GabrielMajeri/ucs2-rs" }
 is-it-maintained-open-issues = { repository = "https://github.com/GabrielMajeri/ucs2-rs" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,10 @@ where
     Ok(())
 }
 
+/// Decode an input UCS-2 string into a UTF-8 string.
+///
+/// The returned `usize` represents the length of the returned buffer,
+/// in bytes.
 pub fn decode(input: &[u16], output: &mut [u8]) -> Result<usize> {
     let buffer_size = output.len();
     let mut i = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,4 +148,17 @@ mod tests {
 
         assert_eq!(buffer[..], [0x0151, 0x044D, 0x254B]);
     }
+
+    #[test]
+    fn decoding() {
+        let input = "$¢ह한";
+        let mut u16_buffer = [0u16; 4];
+        let result = encode(input, &mut u16_buffer);
+        assert_eq!(result.unwrap(), 4);
+
+        let mut u8_buffer = [0u8; 9];
+        let result = decode(&u16_buffer, &mut u8_buffer);
+        assert_eq!(result.unwrap(), 9);
+        assert_eq!(core::str::from_utf8(&u8_buffer[0..9]), Ok("$¢ह한"));
+    }
 }


### PR DESCRIPTION
Adds a method to decode UCS-2 into UTF-8 code-points in a buffer. This buffer can then be used to construct a `&str`.

Also updates the crate to the newest edition.